### PR TITLE
Fixed problem with plists in pcase-let

### DIFF
--- a/burly-revive.el
+++ b/burly-revive.el
@@ -41,7 +41,7 @@
   "Restore the window configuration.
 Configuration CONFIG should be created by
 `burly-revive--window-configuration'."
-  (pcase-let* (((map :frame-width :frame-height :edges :urls :selected-window-edges)
+  (pcase-let* (((map (:frame-width frame-width) (:frame-height frame-height) (:edges edges) (:urls urls) (:selected-window-edges selected-window-edges))
                 config)
                (edges (burly-revive--normalize-edges frame-width frame-height edges))
                (selected-window-edges (car (burly-revive--normalize-edges frame-width frame-height (list selected-window-edges))))


### PR DESCRIPTION
burly-revive seems to expect a newish version of map.el to handle plist short-hand syntax. Perhaps, the old long-hand syntax could be used until this is generally available