### PR TITLE
Doom Emacs Support

### DIFF
--- a/README.org
+++ b/README.org
@@ -55,6 +55,15 @@ The easiest way is to install with [[https://github.com/quelpa/quelpa-use-packag
     :quelpa (burly :fetcher github :repo "alphapapa/burly.el"))
 #+END_SRC
 
+** Doom
+
+Append the following to ~/.doom.d/packages.el:
+
+#+BEGIN_SRC elisp
+(package! burly
+  :recipe (:host github :repo "alphapapa/burly.el"))
+#+END_SRC
+
 ** Manual
 
 1.  Install version 2.1 or later of the =map= library from GNU ELPA.


### PR DESCRIPTION
Add installation instructions for Doom Emacs.
Works great with Doom Emacs, running on-top of emacs 27.1.

I only ever have one issue when using the new burly frames feature, upon restoring frame layout i get the following error message;
`Error (frameset): Undefined color: "unspecified-bg"`
Other than that burly works flawlessly :)