### PR TITLE
completing-read instead of read-string in open bookmark commands.

### DIFF
--- a/README.org
+++ b/README.org
@@ -92,6 +92,10 @@ These commands work on URL strings.  While most users probably won't use these, 
 :TOC:      :depth 0
 :END:
 
+** 0.2-pre
+
+Nothing new yet.
+
 ** 0.1
 
 Initial release.

--- a/README.org
+++ b/README.org
@@ -94,7 +94,8 @@ These commands work on URL strings.  While most users probably won't use these, 
 
 ** 0.2-pre
 
-Nothing new yet.
+*Added*
++  Bookmark commands use ~completing-read~ and offer existing Burly bookmark names, making it easier to update bookmarks.  (Thanks to [[https://github.com/Kungsgeten][Erik Sjöstrand]].)
 
 ** 0.1
 

--- a/burly.el
+++ b/burly.el
@@ -147,7 +147,9 @@ See Info node `(elisp)Window Parameters'."
 ;;;###autoload
 (defun burly-bookmark-frames (name)
   "Bookmark the current frames as NAME."
-  (interactive (list (read-string "Save Burly bookmark: " burly-bookmark-prefix)))
+  (interactive (list (completing-read
+                      "Save Burly bookmark: "
+                      (burly-bookmark-names) nil nil burly-bookmark-prefix)))
   (let ((record (list (cons 'url (burly-frames-url))
                       (cons 'handler #'burly-bookmark-handler))))
     (bookmark-store name record nil)))
@@ -155,7 +157,9 @@ See Info node `(elisp)Window Parameters'."
 ;;;###autoload
 (defun burly-bookmark-windows (name)
   "Bookmark the current frame's window configuration as NAME."
-  (interactive (list (read-string "Save Burly bookmark: " burly-bookmark-prefix)))
+  (interactive (list (completing-read
+                      "Save Burly bookmark: "
+                      (burly-bookmark-names) nil nil burly-bookmark-prefix)))
   (let ((record (list (cons 'url (burly-windows-url))
                       (cons 'handler #'burly-bookmark-handler))))
     (bookmark-store name record nil)))
@@ -164,12 +168,8 @@ See Info node `(elisp)Window Parameters'."
 (defun burly-open-bookmark (bookmark)
   "Restore a window configuration to the current frame from a Burly BOOKMARK."
   (interactive
-   (let ((bookmark-names (cl-loop for bookmark in bookmark-alist
-                                  for (_name . params) = bookmark
-                                  when (equal #'burly-bookmark-handler (alist-get 'handler params))
-                                  collect (car bookmark))))
-     (list (completing-read "Open Burly bookmark: " bookmark-names
-			    nil nil burly-bookmark-prefix))))
+   (list (completing-read "Open Burly bookmark: " (burly-bookmark-names)
+			  nil nil burly-bookmark-prefix)))
   (cl-assert (and bookmark (not (string-empty-p bookmark))) nil
              "(burly-open-bookmark): Invalid Burly bookmark: '%s'" bookmark)
   (bookmark-jump bookmark))
@@ -385,6 +385,13 @@ URLOBJ should be a URL object as returned by
           (bookmark-jump record)
         (error (delay-warning 'burly (format "Error while opening bookmark: ERROR:%S  RECORD:%S" err record))))
       (current-buffer))))
+
+(defun burly-bookmark-names ()
+  "Return list of all Burly bookmark names."
+  (cl-loop for bookmark in bookmark-alist
+           for (_name . params) = bookmark
+           when (equal #'burly-bookmark-handler (alist-get 'handler params))
+           collect (car bookmark)))
 
 ;;;;; Org buffers
 

--- a/burly.el
+++ b/burly.el
@@ -147,9 +147,9 @@ See Info node `(elisp)Window Parameters'."
 ;;;###autoload
 (defun burly-bookmark-frames (name)
   "Bookmark the current frames as NAME."
-  (interactive (list (completing-read
-                      "Save Burly bookmark: "
-                      (burly-bookmark-names) nil nil burly-bookmark-prefix)))
+  (interactive
+   (list (completing-read "Save Burly bookmark: " (burly-bookmark-names)
+                          nil nil burly-bookmark-prefix)))
   (let ((record (list (cons 'url (burly-frames-url))
                       (cons 'handler #'burly-bookmark-handler))))
     (bookmark-store name record nil)))
@@ -157,9 +157,9 @@ See Info node `(elisp)Window Parameters'."
 ;;;###autoload
 (defun burly-bookmark-windows (name)
   "Bookmark the current frame's window configuration as NAME."
-  (interactive (list (completing-read
-                      "Save Burly bookmark: "
-                      (burly-bookmark-names) nil nil burly-bookmark-prefix)))
+  (interactive
+   (list (completing-read "Save Burly bookmark: " (burly-bookmark-names)
+                          nil nil burly-bookmark-prefix)))
   (let ((record (list (cons 'url (burly-windows-url))
                       (cons 'handler #'burly-bookmark-handler))))
     (bookmark-store name record nil)))

--- a/burly.el
+++ b/burly.el
@@ -4,7 +4,7 @@
 
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; URL: https://github.com/alphapapa/burly.el
-;; Version: 0.1
+;; Version: 0.2-pre
 ;; Package-Requires: ((emacs "26.3") (map "2.1"))
 ;; Keywords: convenience
 

--- a/burly.info
+++ b/burly.info
@@ -40,6 +40,7 @@ Usage
 
 Changelog
 
+* 0.2-pre: 02-pre. 
 * 0.1: 01. 
 
 This package provides tools to save and restore frame and window
@@ -183,12 +184,21 @@ File: README.info,  Node: Changelog,  Next: Development,  Prev: Usage,  Up: Top
 
 * Menu:
 
+* 0.2-pre: 02-pre. 
 * 0.1: 01. 
 
 
-File: README.info,  Node: 01,  Up: Changelog
+File: README.info,  Node: 02-pre,  Next: 01,  Up: Changelog
 
-3.1 0.1
+3.1 0.2-pre
+===========
+
+Nothing new yet.
+
+
+File: README.info,  Node: 01,  Prev: 02-pre,  Up: Changelog
+
+3.2 0.1
 =======
 
 Initial release.
@@ -222,19 +232,20 @@ GPLv3
 
 Tag Table:
 Node: Top219
-Node: Installation2308
-Node: MELPA2459
-Node: Quelpa2631
-Node: Manual2944
-Node: Usage3195
-Node: Bookmark commands3354
-Node: URL commands4027
-Node: Tips4681
-Node: Changelog4875
-Node: 015005
-Node: Development5088
-Node: Credits5259
-Node: License5492
+Node: Installation2328
+Node: MELPA2479
+Node: Quelpa2651
+Node: Manual2964
+Node: Usage3215
+Node: Bookmark commands3374
+Node: URL commands4047
+Node: Tips4701
+Node: Changelog4895
+Node: 02-pre5045
+Node: 015151
+Node: Development5249
+Node: Credits5420
+Node: License5653
 
 End Tag Table
 

--- a/burly.info
+++ b/burly.info
@@ -193,7 +193,10 @@ File: README.info,  Node: 02-pre,  Next: 01,  Up: Changelog
 3.1 0.2-pre
 ===========
 
-Nothing new yet.
+*Added*
+   • Bookmark commands use ‘completing-read’ and offer existing Burly
+     bookmark names, making it easier to update bookmarks.  (Thanks to
+     Erik Sjöstrand (https://github.com/Kungsgeten).)
 
 
 File: README.info,  Node: 01,  Prev: 02-pre,  Up: Changelog
@@ -242,10 +245,10 @@ Node: URL commands4047
 Node: Tips4701
 Node: Changelog4895
 Node: 02-pre5045
-Node: 015151
-Node: Development5249
-Node: Credits5420
-Node: License5653
+Node: 015344
+Node: Development5442
+Node: Credits5613
+Node: License5846
 
 End Tag Table
 


### PR DESCRIPTION
Implements #25. Also adds function `burly-bookmark-names` (copied from let-form in `burly-open-bookmark`).