### PR TITLE
Fix: Encode/decode file path in emacs+burly+file url

### DIFF
--- a/burly.el
+++ b/burly.el
@@ -244,7 +244,7 @@ a project."
   "Return buffer for \"emacs+burly+file:\" URLOBJ."
   (pcase-let* ((`(,path . ,query-string) (url-path-and-query urlobj))
                (query (url-parse-query-string query-string))
-               (buffer (find-file-noselect path))
+               (buffer (find-file-noselect (decode-coding-string path 'utf-8-unix)))
                (major-mode (buffer-local-value 'major-mode buffer))
                (follow-fn (map-nested-elt burly-major-mode-alist (list major-mode 'follow-url-fn))))
     (cl-assert follow-fn nil "Major mode not in `burly-major-mode-alist': %s" major-mode)
@@ -499,7 +499,7 @@ URLOBJ should be a URL object as returned by
                             (buffer-file-name (buffer-base-buffer buffer))))
            (filename (concat buffer-file "?" (url-build-query-string (remove nil query)))))
       (url-recreate-url (url-parse-make-urlobj "emacs+burly+file" nil nil nil nil
-                                               filename nil nil 'fullness)))))
+                                               (encode-coding-string filename 'utf-8-unix) nil nil 'fullness)))))
 
 (cl-defun burly-follow-url-org-mode (&key buffer query)
   "In BUFFER, jump to heading and position from QUERY, and return a buffer.

--- a/burly.el
+++ b/burly.el
@@ -497,9 +497,9 @@ URLOBJ should be a URL object as returned by
                           (list "narrowed" "t"))))
            (buffer-file (or (buffer-file-name buffer)
                             (buffer-file-name (buffer-base-buffer buffer))))
-           (filename (concat buffer-file "?" (url-build-query-string (remove nil query)))))
+           (filename (concat (encode-coding-string buffer-file 'utf-8-unix) "?" (url-build-query-string (remove nil query)))))
       (url-recreate-url (url-parse-make-urlobj "emacs+burly+file" nil nil nil nil
-                                               (encode-coding-string filename 'utf-8-unix) nil nil 'fullness)))))
+                                               filename nil nil 'fullness)))))
 
 (cl-defun burly-follow-url-org-mode (&key buffer query)
   "In BUFFER, jump to heading and position from QUERY, and return a buffer.

--- a/burly.el
+++ b/burly.el
@@ -523,7 +523,7 @@ indirect buffer is returned.  Otherwise BUFFER is returned."
                          ("relative-pos" relative-pos))
                     query)
                    (heading-pos (when top-olp
-                                  (org-find-olp (read top-olp) 'this-buffer))))
+                                  (org-find-olp (read (decode-coding-string top-olp 'utf-8-unix)) 'this-buffer))))
         (widen)
         (if heading-pos
             (goto-char heading-pos)
@@ -531,7 +531,7 @@ indirect buffer is returned.  Otherwise BUFFER is returned."
         (cond (indirect (org-tree-to-indirect-buffer))
               (narrowed (progn
                           (org-narrow-to-subtree)
-                          (goto-char (org-find-olp (read point-olp) 'this-buffer)))))
+                          (goto-char (org-find-olp (read (decode-coding-string point-olp 'utf-8-unix)) 'this-buffer)))))
         (when (and heading-pos relative-pos)
           (forward-char (string-to-number relative-pos)))
         (current-buffer)))))


### PR DESCRIPTION
This PR adds encoding/decoding of file path in `emacs+burly+file` url, fixes #43