### PR TITLE
Fix #46

### DIFF
--- a/burly.el
+++ b/burly.el
@@ -436,6 +436,7 @@ URLOBJ should be a URL object as returned by
 
 (defun burly-bookmark-names ()
   "Return list of all Burly bookmark names."
+  (bookmark-maybe-load-default-file)
   (cl-loop for bookmark in bookmark-alist
            for (_name . params) = bookmark
            when (equal #'burly-bookmark-handler (alist-get 'handler params))


### PR DESCRIPTION
Calling `(bookmark-maybe-load-default-file)` in the function definition of `burly-bookmark-names` loads the bookmark file prior to being read by Burly so that bookmarks are ready to be accessed by `burly-open-bookmark`.